### PR TITLE
Update firmware to v1.2.3

### DIFF
--- a/port/app/board/inc/WIZnet_board.h
+++ b/port/app/board/inc/WIZnet_board.h
@@ -24,7 +24,7 @@ typedef enum {RESET = 0, SET = !RESET} FlagStatus, ITStatus;
 
 #if ((DEVICE_BOARD_NAME == WIZ5XXSR_RP) || DEVICE_BOARD_NAME == W55RP20_S2E || DEVICE_BOARD_NAME == W232N || DEVICE_BOARD_NAME == IP20 || DEVICE_BOARD_NAME == PLATYPUS_S2E) // Chip product
 //#define __USE_DHCP_INFINITE_LOOP__          // When this option is enabled, if DHCP IP allocation failed, process_dhcp() function will try to DHCP steps again.
-//#define __USE_DNS_INFINITE_LOOP__           // When this option is enabled, if DNS query failed, process_dns() function will try to DNS steps again.
+#define __USE_DNS_INFINITE_LOOP__           // When this option is enabled, if DNS query failed, process_dns() function will try to DNS steps again.
 #define __USE_HW_FACTORY_RESET__            // Use Factory reset pin
 #define __USE_SAFE_SAVE__                   // When this option is enabled, data verify is additionally performed in the flash save of config-data.
 #define __USE_WATCHDOG__                  // WDT timeout 30 Second

--- a/port/app/configuration/inc/common.h
+++ b/port/app/configuration/inc/common.h
@@ -9,7 +9,7 @@
 /* Application Firmware Version */
 #define MAJOR_VER               1
 #define MINOR_VER               2
-#define MAINTENANCE_VER         2
+#define MAINTENANCE_VER         3
 
 #define DEV_CONFIG_VER          104
 

--- a/port/app/mbedtls/src/SSLInterface.c
+++ b/port/app/mbedtls/src/SSLInterface.c
@@ -287,8 +287,8 @@ void wiz_tls_deinit(wiz_tls_context* tlsContext) {
 int wiz_tls_socket(wiz_tls_context* tlsContext, uint8_t sock, unsigned int port) {
     /*socket open*/
     tlsContext->socket_fd = sock;
-    //return socket((uint8_t)(tlsContext->socket_fd), Sn_MR_TCP, (uint16_t)port, (SF_TCP_NODELAY | SF_IO_NONBLOCK));
-    return socket((uint8_t)(tlsContext->socket_fd), Sn_MR_TCP, (uint16_t)port, 0x00);
+    return socket((uint8_t)(tlsContext->socket_fd), Sn_MR_TCP, (uint16_t)port, (SF_TCP_NODELAY | SF_IO_NONBLOCK));
+    //return socket((uint8_t)(tlsContext->socket_fd), Sn_MR_TCP, (uint16_t)port, 0x00);
 }
 
 int wiz_tls_connect(wiz_tls_context* tlsContext, char * addr, unsigned int port) {
@@ -336,7 +336,7 @@ int wiz_tls_socket_connect(wiz_tls_context* tlsContext, char * addr, unsigned in
     char error_buf[1024];
 #endif
     /*socket open*/
-    ret = socket(sock, Sn_MR_TCP, 0, 0x00);
+    ret = socket(sock, Sn_MR_TCP, 0, (SF_TCP_NODELAY | SF_IO_NONBLOCK));
     if (ret != sock) {
         return ret;
     }

--- a/port/app/platform_handler/src/deviceHandler.c
+++ b/port/app/platform_handler/src/deviceHandler.c
@@ -116,6 +116,7 @@ uint8_t device_bank_update(void) {
     uint32_t f_addr;
     uint32_t remain_len = 0, buf_len = 0;
     uint8_t *temp_buf;
+    uint8_t *recv_temp_buf;
 
     if ((fwupdate->fwup_size == 0) || (fwupdate->fwup_size > FLASH_APP_BANK_SIZE)) {
         if (serial_common->serial_debug_en)
@@ -139,28 +140,32 @@ uint8_t device_bank_update(void) {
     temp_buf = pvPortMalloc(FLASH_SECTOR_SIZE);
     memset(temp_buf, 0x00, FLASH_SECTOR_SIZE);
 
+    recv_temp_buf = pvPortMalloc(FLASH_SECTOR_SIZE);
+    memset(recv_temp_buf, 0x00, FLASH_SECTOR_SIZE);
+
+
     do {
 
 #ifdef __USE_WATCHDOG__
         device_wdt_reset();
 #endif
-        recv_len = get_firmware_from_network(SOCK_FWUPDATE, g_recv_buf);
+        recv_len = get_firmware_from_network(SOCK_FWUPDATE, recv_temp_buf);
         if (recv_len > 0) {
             xTimerReset(reset_timer, 0);
             if (buf_len + recv_len < FLASH_SECTOR_SIZE) {
-                memcpy(temp_buf + buf_len, g_recv_buf, recv_len);
+                memcpy(temp_buf + buf_len, recv_temp_buf, recv_len);
                 buf_len += recv_len;
             } else {
                 //printf("f_addr = 0x%x\r\n", f_addr);
                 remain_len = (buf_len + recv_len) - FLASH_SECTOR_SIZE;
-                memcpy(temp_buf + buf_len, g_recv_buf, recv_len - remain_len);
+                memcpy(temp_buf + buf_len, recv_temp_buf, recv_len - remain_len);
 
                 PRT_INFO("Write_addr = 0x%08X\r\n", f_addr);
                 write_flash(f_addr, (uint8_t *)temp_buf, FLASH_SECTOR_SIZE);
                 f_addr += FLASH_SECTOR_SIZE;
 
                 memset(temp_buf, 0xFF, FLASH_SECTOR_SIZE);
-                memcpy(temp_buf, g_recv_buf + (recv_len - remain_len), remain_len);
+                memcpy(temp_buf, recv_temp_buf + (recv_len - remain_len), remain_len);
                 buf_len = remain_len;
             }
             write_fw_len += recv_len;
@@ -182,6 +187,7 @@ uint8_t device_bank_update(void) {
         ret = DEVICE_FWUP_RET_SUCCESS;
     }
     vPortFree(temp_buf);
+    vPortFree(recv_temp_buf);
     xTimerStop(reset_timer, 0);
     return ret;
 }

--- a/port/app/platform_handler/src/dnsHandler.c
+++ b/port/app/platform_handler/src/dnsHandler.c
@@ -18,6 +18,7 @@
 #include "port_common.h"
 #include "timerHandler.h"
 #include "seg.h"
+#include "deviceHandler.h"
 
 /* Header for all domain messages */
 struct dhdr_handler {
@@ -171,6 +172,8 @@ int8_t process_dns(void) {
         if (dev_config->network_option.dhcp_use) {
             DHCP_run();
         }
+
+        device_wdt_reset();
     } while (ret != TRUE);
 
     if (get_device_status() != ST_ATMODE) {

--- a/port/app/platform_handler/src/dnsHandler.c
+++ b/port/app/platform_handler/src/dnsHandler.c
@@ -149,9 +149,9 @@ int8_t process_dns(void) {
 #ifdef _MAIN_DEBUG_
     printf(" - DNS Client running\r\n");
 #endif
-    if (get_device_status() != ST_ATMODE) {
-        set_device_status(ST_UPGRADE);
-    }
+    //    if (get_device_status() != ST_ATMODE) {
+    //        set_device_status(ST_UPGRADE);
+    //    }
 
     do {
         ret = get_ipaddr_from_dns((uint8_t *)dev_config->network_connection.dns_domain_name,
@@ -176,9 +176,9 @@ int8_t process_dns(void) {
         device_wdt_reset();
     } while (ret != TRUE);
 
-    if (get_device_status() != ST_ATMODE) {
-        set_device_status(ST_OPEN);
-    }
+    //  if (get_device_status() != ST_ATMODE) {
+    //        set_device_status(ST_OPEN);
+    //    }
     return ret;
 }
 

--- a/port/app/serial_to_ethernet/src/seg.c
+++ b/port/app/serial_to_ethernet/src/seg.c
@@ -2215,8 +2215,8 @@ void seg_u2e_task(void *argument)  {
             xSemaphoreTake(seg_critical_sem, portMAX_DELAY);
             if (get_data_buffer_usedsize() || u2e_size) {
                 if ((network_connection->working_mode == TCP_MIXED_MODE) && (mixed_state == MIXED_SERVER) && (ST_OPEN == get_device_status())) {
-                    process_socket_termination(SEG_DATA0_SOCK, SOCK_TERMINATION_DELAY, FALSE);
                     mixed_state = MIXED_CLIENT;
+                    process_socket_termination(SEG_DATA0_SOCK, SOCK_TERMINATION_DELAY, FALSE);
                     xSemaphoreGive(seg_sem);
                 } else if ((ST_CONNECT == get_device_status()) || network_connection->working_mode == UDP_MODE) {
                     uart_to_ether(SEG_DATA0_SOCK);

--- a/port/app/serial_to_ethernet/src/seg.c
+++ b/port/app/serial_to_ethernet/src/seg.c
@@ -372,11 +372,8 @@ void proc_SEG_tcp_client(uint8_t sock) {
         }
         // TCP connect
         ret = connect(sock, network_connection->remote_ip, network_connection->remote_port);
-        if (ret < 0) {
-            PRT_SEG(" > SEG:TCP_CLIENT_MODE:ConnectNetwork Err %d\r\n", ret);
-            process_socket_termination(sock, SOCK_TERMINATION_DELAY, FALSE);
-            break;
-        }
+        PRT_SEG(" > SEG:TCP_CLIENT_MODE:ConnectNetwork Err %d\r\n", ret);
+
 #ifdef _SEG_DEBUG_
         PRT_SEG(" > SEG:TCP_CLIENT_MODE:CLIENT_CONNECTION\r\n");
 #endif
@@ -451,7 +448,7 @@ void proc_SEG_tcp_client(uint8_t sock) {
 #ifdef _SEG_DEBUG_
         PRT_SEG(" > TCP CLIENT: client_any_port = %d\r\n", client_any_port);
 #endif
-        int8_t s = socket(sock, Sn_MR_TCP, source_port, 0x00);
+        int8_t s = socket(sock, Sn_MR_TCP, source_port, (SF_TCP_NODELAY | SF_IO_NONBLOCK));
 
         if (s == sock) {
             if ((serial_command->serial_command == SEG_ENABLE) && serial_data_packing->packing_time) {
@@ -479,6 +476,7 @@ void proc_SEG_tcp_client(uint8_t sock) {
 void proc_SEG_tcp_client_over_tls(uint8_t sock) {
     struct __tcp_option *tcp_option = (struct __tcp_option *) & (get_DevConfig_pointer()->tcp_option);
     struct __network_connection *network_connection = (struct __network_connection *) & (get_DevConfig_pointer()->network_connection);
+    struct __network_option *network_option = (struct __network_option *) & (get_DevConfig_pointer()->network_option);
     struct __serial_data_packing *serial_data_packing = (struct __serial_data_packing *) & (get_DevConfig_pointer()->serial_data_packing);
     struct __serial_common *serial_common = (struct __serial_common *)&get_DevConfig_pointer()->serial_common;
     struct __serial_command *serial_command = (struct __serial_command *)&get_DevConfig_pointer()->serial_command;
@@ -511,8 +509,23 @@ void proc_SEG_tcp_client_over_tls(uint8_t sock) {
         ctlsocket(sock, CS_SET_INTMASK, (void *)&reg_val);
 
         ret = connect(sock, network_connection->remote_ip, network_connection->remote_port);
-        if (ret < 0) {
-            PRT_SEG(" > SEG:TCP_CLIENT_OVER_TLS_MODE:ConnectNetwork Err %d\r\n", ret);
+        PRT_SEG(" > SEG:TCP_CLIENT_OVER_TLS_MODE:ConnectNetwork Err %d\r\n", ret);
+
+        // Wait for TCP connection with timeout (1s * tcp_rcr_val)
+        uint32_t timeout_ticks = pdMS_TO_TICKS(1000 * network_option->tcp_rcr_val);
+        uint32_t elapsed_ticks = 0;
+        const uint32_t poll_ticks = pdMS_TO_TICKS(10);
+
+        while (elapsed_ticks < timeout_ticks) {
+            if (getSn_SR(sock) == SOCK_ESTABLISHED) {
+                break;
+            }
+            vTaskDelay(poll_ticks);
+            elapsed_ticks += poll_ticks;
+        }
+
+        if (getSn_SR(sock) != SOCK_ESTABLISHED) {
+            PRT_SEG(" > SEG:TCP_CLIENT_OVER_TLS_MODE: TCP CONNECT TIMEOUT\r\n");
             process_socket_termination(sock, SOCK_TERMINATION_DELAY, FALSE);
             break;
         }
@@ -652,6 +665,7 @@ void proc_SEG_tcp_client_over_tls(uint8_t sock) {
 void proc_SEG_mqtt_client(uint8_t sock) {
     struct __tcp_option *tcp_option = (struct __tcp_option *) & (get_DevConfig_pointer()->tcp_option);
     struct __network_connection *network_connection = (struct __network_connection *) & (get_DevConfig_pointer()->network_connection);
+    struct __network_option *network_option = (struct __network_option *) & (get_DevConfig_pointer()->network_option);
     struct __serial_data_packing *serial_data_packing = (struct __serial_data_packing *) & (get_DevConfig_pointer()->serial_data_packing);
     struct __serial_common *serial_common = (struct __serial_common *)&get_DevConfig_pointer()->serial_common;
     struct __serial_command *serial_command = (struct __serial_command *)&get_DevConfig_pointer()->serial_command;
@@ -683,11 +697,27 @@ void proc_SEG_mqtt_client(uint8_t sock) {
 
         // MQTT connect
         ret = connect(sock, network_connection->remote_ip, network_connection->remote_port);
-        if (ret < 0) {
-            PRT_SEG(" > SEG:MQTT_CLIENT_MODE:ConnectNetwork Err %d\r\n", ret);
+        PRT_SEG(" > SEG:MQTT_CLIENT_MODE:ConnectNetwork Err %d\r\n", ret);
+
+        // Wait for TCP connection with timeout (1s * tcp_rcr_val)
+        uint32_t timeout_ticks = pdMS_TO_TICKS(1000 * network_option->tcp_rcr_val);
+        uint32_t elapsed_ticks = 0;
+        const uint32_t poll_ticks = pdMS_TO_TICKS(10);
+
+        while (elapsed_ticks < timeout_ticks) {
+            if (getSn_SR(sock) == SOCK_ESTABLISHED) {
+                break;
+            }
+            vTaskDelay(poll_ticks);
+            elapsed_ticks += poll_ticks;
+        }
+
+        if (getSn_SR(sock) != SOCK_ESTABLISHED) {
+            PRT_SEG(" > SEG:TCP_CLIENT_OVER_TLS_MODE: TCP CONNECT TIMEOUT\r\n");
             process_socket_termination(sock, SOCK_TERMINATION_DELAY, FALSE);
             break;
         }
+
         PRT_SEG(" > SEG:MQTT_CLIENT_MODE:TCP_CONNECTION\r\n");
 
         reg_val = SIK_ALL & 0x00FF;
@@ -785,7 +815,7 @@ void proc_SEG_mqtt_client(uint8_t sock) {
         }
 
         PRT_SEG(" > MQTT CLIENT: client_any_port = %d\r\n", client_any_port);
-        int8_t s = socket(sock, Sn_MR_TCP, source_port, 0x00);
+        int8_t s = socket(sock, Sn_MR_TCP, source_port, (SF_TCP_NODELAY | SF_IO_NONBLOCK));
 
         if (s == sock) {
             // Replace the command mode switch code GAP time (default: 500ms)
@@ -822,6 +852,7 @@ void proc_SEG_mqtt_client(uint8_t sock) {
 void proc_SEG_mqtts_client(uint8_t sock) {
     struct __tcp_option *tcp_option = (struct __tcp_option *) & (get_DevConfig_pointer()->tcp_option);
     struct __network_connection *network_connection = (struct __network_connection *) & (get_DevConfig_pointer()->network_connection);
+    struct __network_option *network_option = (struct __network_option *) & (get_DevConfig_pointer()->network_option);
     struct __serial_data_packing *serial_data_packing = (struct __serial_data_packing *) & (get_DevConfig_pointer()->serial_data_packing);
     struct __serial_common *serial_common = (struct __serial_common *)&get_DevConfig_pointer()->serial_common;
     struct __serial_command *serial_command = (struct __serial_command *)&get_DevConfig_pointer()->serial_command;
@@ -851,11 +882,27 @@ void proc_SEG_mqtts_client(uint8_t sock) {
         ctlsocket(sock, CS_SET_INTMASK, (void *)&reg_val);
 
         ret = connect(sock, network_connection->remote_ip, network_connection->remote_port);
-        if (ret < 0) {
-            PRT_SEG(" > SEG:TCP_CLIENT_OVER_TLS_MODE:ConnectNetwork Err %d\r\n", ret);
+        PRT_SEG(" > SEG:TCP_CLIENT_OVER_TLS_MODE:ConnectNetwork Err %d\r\n", ret);
+
+        // Wait for TCP connection with timeout (1s * tcp_rcr_val)
+        uint32_t timeout_ticks = pdMS_TO_TICKS(1000 * network_option->tcp_rcr_val);
+        uint32_t elapsed_ticks = 0;
+        const uint32_t poll_ticks = pdMS_TO_TICKS(10);
+
+        while (elapsed_ticks < timeout_ticks) {
+            if (getSn_SR(sock) == SOCK_ESTABLISHED) {
+                break;
+            }
+            vTaskDelay(poll_ticks);
+            elapsed_ticks += poll_ticks;
+        }
+
+        if (getSn_SR(sock) != SOCK_ESTABLISHED) {
+            PRT_SEG(" > SEG:TCP_CLIENT_OVER_TLS_MODE: TCP CONNECT TIMEOUT\r\n");
             process_socket_termination(sock, SOCK_TERMINATION_DELAY, FALSE);
             break;
         }
+
         reg_val = SIK_ALL & 0x00FF;
         ctlsocket(sock, CS_CLR_INTERRUPT, (void *)&reg_val);
 
@@ -1172,10 +1219,7 @@ void proc_SEG_tcp_mixed(uint8_t sock) {
 
             // TCP connect
             ret = connect(sock, network_connection->remote_ip, network_connection->remote_port);
-            if (ret < 0) {
-                PRT_SEG(" > SEG:TCP_MIXED_MODE:ConnectNetwork Err %d\r\n", ret);
-                process_socket_termination(sock, SOCK_TERMINATION_DELAY, FALSE);
-            }
+            PRT_SEG(" > SEG:TCP_MIXED_MODE:ConnectNetwork Err %d\r\n", ret);
 
 #ifdef MIXED_CLIENT_LIMITED_CONNECT
             reconnection_count++;
@@ -1287,7 +1331,7 @@ void proc_SEG_tcp_mixed(uint8_t sock) {
             e2u_size = 0;
             data_buffer_flush();
 
-            int8_t s = socket(sock, Sn_MR_TCP, network_connection->local_port, 0x00);
+            int8_t s = socket(sock, Sn_MR_TCP, network_connection->local_port, (SF_TCP_NODELAY | SF_IO_NONBLOCK));
 
             if (s == sock) {
                 // Replace the command mode switch code GAP time (default: 500ms)
@@ -1319,7 +1363,7 @@ void proc_SEG_tcp_mixed(uint8_t sock) {
 #ifdef _SEG_DEBUG_
             PRT_SEG(" > TCP CLIENT: any_port = %d\r\n", source_port);
 #endif
-            int8_t s = socket(sock, Sn_MR_TCP, source_port, 0x00);
+            int8_t s = socket(sock, Sn_MR_TCP, source_port, (SF_TCP_NODELAY | SF_IO_NONBLOCK));
 
             if (s == sock) {
                 // Replace the command mode switch code GAP time (default: 500ms)


### PR DESCRIPTION
## Summary

This PR updates the firmware version to **v1.2.3** and includes fixes for TCP client connection handling, DHCP status transition behavior, firmware update stability during data transmission, DNS retry handling, and timer flag processing.

## Changes

### Fix TCP client connection handling and DHCP status transition

- Changed the status transition from `Upgrade` to `OPEN` to occur only when DHCP is terminated, instead of both DHCP and DNS termination.
  - This fixes an issue where the Configuration Tool could not be used when an incorrect DNS value was entered.

- Fixed an issue in v1.2.2 where the Configuration Tool could not be used if the TCP Client Base protocol failed to connect.

- Added wait handling after TCP Client Connect in SSL Client, MQTT, and MQTTS modes until the connection is completed.
  - The timeout is proportional to the Retransmission Retry Count.
  - Timeout rule: 1 second per retry count.

### Fix firmware update error during data transmission

- Fixed an issue that could occur when performing a firmware update while data transfer is in progress.

### Enable infinite DNS retry and prevent WDT reset

- Enabled infinite DNS retry handling.
- Prevented watchdog timer reset during repeated DNS retry operations.

### Change mixed state before disabling timer flag

- Changed the mixed state before disabling the timer flag to ensure proper state handling.

## Test

- Verified that the status changes from `Upgrade` to `OPEN` only after DHCP termination.
- Verified that the Configuration Tool can be used even when an incorrect DNS value is configured.
- Verified that the Configuration Tool remains available when TCP Client Base fails to connect.
- Verified connection wait handling in SSL Client, MQTT, and MQTTS modes.
- Verified firmware update behavior during data transmission.
- Verified DNS retry behavior without watchdog timer reset.
- Verified mixed state handling before disabling the timer flag.